### PR TITLE
fix whitespace issue when comparing tags

### DIFF
--- a/js/jportilio.js
+++ b/js/jportilio.js
@@ -13,6 +13,7 @@ $(function () {
 				
 				if(tags != null && tags.length > 0) {
 					var found = false;
+					tags = tags.replace(/ /g,'');//clear whitespace to match tags better
 					tags = tags.split(',');
 					tags.map(function(a) {
 						if($.inArray(a,opts.filter) != -1) {

--- a/js/jportilio.js
+++ b/js/jportilio.js
@@ -14,6 +14,7 @@ $(function () {
 				if(tags != null && tags.length > 0) {
 					var found = false;
 					tags = tags.replace(/ /g,'');//clear whitespace to match tags better
+					tags = tags.toLowerCase();//standardize case to match tags better
 					tags = tags.split(',');
 					tags.map(function(a) {
 						if($.inArray(a,opts.filter) != -1) {
@@ -208,7 +209,10 @@ $(function () {
 			/* tag filter buttons click: */
 			$('button[data-jprtgrid='+obj.attr('id')+']').on('click', function(e) {
 				var tag = $(this).data('tag');
-                if(tag != null) { tag = tag.split(',');}
+                if(tag != null) { 
+      						tag = tag.replace(/ /g,'');	//clear whitespace to match better
+      						tag = tag.toLowerCase(); 		//standardize case to match better
+      						tag = tag.split(',');}
 				
 				// check if button is active and add or remove tags:
 				if($(this).hasClass('jprt-btn-active')) {


### PR DESCRIPTION
I was having an issue with the matching of variables.

```
"new, frank"
```

would be split as
`"new"` and `" frank"` with a leading whitespace.

similar issue with trailing whitespace.

I added

```
tags = tags.replace(/ /g,'');
```

to strip whitespace prior to splitting.
